### PR TITLE
Adding new dependency of latest framework

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ genie
 jinja2
 stcrestclient
 robotframework
+requests
+requests_toolbelt


### PR DESCRIPTION
Seeing issue in test setup of internal customers.
Package "requests_toolbelt" is missing after deployment.